### PR TITLE
Powercab, XAir, and RC-10R

### DIFF
--- a/data/brands/behringer/xair
+++ b/data/brands/behringer/xair
@@ -1,0 +1,216 @@
+midi_in: DIN5
+
+
+midi_channel:
+  instructions: |+
+    The X Air 12, 16, 18 can be automated via MIDI. Obviously if you use an input channel you don't have on your mixer, it won't have any effect.
+    The X Air 18 can also act as an MIDI interface.
+    It may need to be enabled in Setup -> Audio/MIDI.
+    It is hardwired to use MIDI channels 1-3. Channel 1 is the Faders, channel 2 the mutes (0 pr 127), and channel 3 PAN/balance (64 = center).
+    In other words, all the CC messages below will control the fader, mute, or PAN depending what channel you use (1-3.)
+    The X Air also supports MIDI SYX messages which are not listed below.
+pc:
+  description: |+
+    PC#1 (00H) recalls snapshot 1
+    PC#2 (01H) recalls snapshot 2
+    etc through 64
+   
+cc:
+  - name: Input Channel 1
+    value: 0
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 2
+    value: 1
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 3
+    value: 2
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 4
+    value: 3
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 5
+    value: 4
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 6
+    value: 5
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 7
+    value: 6
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 8
+    value: 7
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 9
+    value: 8
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 10
+    value: 9
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 11
+    value: 10
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 12
+    value: 11
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 13
+    value: 12
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 14
+    value: 13
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 15
+    value: 14
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input Channel 16
+    value: 15
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127        
+  - name: AuxLine 17-18/USB Recorder Playback
+    value: 16
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX1 Return
+    value: 17
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX1 Return
+    value: 17
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX2 Return
+    value: 18
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX3 Return
+    value: 19
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX4 Return
+    value: 20
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Aux 1 / Subgroup
+    value: 21
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Aux 2 / Subgroup
+    value: 22
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Aux 3 / Subgroup
+    value: 23
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Aux 4 / Subgroup
+    value: 24
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Aux 5 / Subgroup
+    value: 25
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Aux 6 / Subgroup
+    value: 26
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX1
+    value: 27
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX2
+    value: 28
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX3
+    value: 29
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: FX4
+    value: 30
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Main LR
+    value: 31
+    description: '0-127'
+    type: Parameter
+    min: 0
+    max: 127

--- a/data/brands/behringer/xair
+++ b/data/brands/behringer/xair
@@ -6,7 +6,7 @@ midi_channel:
     The X Air 12, 16, 18 can be automated via MIDI. Obviously if you use an input channel you don't have on your mixer, it won't have any effect.
     The X Air 18 can also act as an MIDI interface.
     It may need to be enabled in Setup -> Audio/MIDI.
-    It is hardwired to use MIDI channels 1-3. Channel 1 is the Faders, channel 2 the mutes (0 pr 127), and channel 3 PAN/balance (64 = center).
+    It is hardwired to use MIDI channels 1-3. Channel 1 is the Faders, channel 2 the mutes (0 or 127), and channel 3 PAN/balance (64 = center).
     In other words, all the CC messages below will control the fader, mute, or PAN depending what channel you use (1-3.)
     The X Air also supports MIDI SYX messages which are not listed below.
 pc:

--- a/data/brands/boss/rc10r.yaml
+++ b/data/brands/boss/rc10r.yaml
@@ -23,33 +23,65 @@ cc:
     max: 95
   - name: Rhy Division - Switch rhythm between PTN1 and PTN2
     value: 2
+    min: 0
+    max: 127
   - name: Rhy Fillin - Play a fill-in
     value: 3
+    min: 0
+    max: 127
   - name: Rhy Stop - Stops the rhythm
     value: 4
+    min: 0
+    max: 127
   - name: Rhy Break - Break the rhythm playback
     value: 5
+    min: 0
+    max: 127
   - name: Rhy Level - Adjust the rhythm playback level
     value: 6
+    min: 0
+    max: 127
   - name: Loop Start - Start the Looper
     value: 7
+    min: 0
+    max: 127
   - name: Loop Stop - Stop the Looper
     value: 8
+    min: 0
+    max: 127
   - name: TRK1 Start - Play TRK1
     value: 9
+    min: 0
+    max: 127
   - name: TRK1 Stop - Stop TRK1
     value: 10
+    min: 0
+    max: 127
   - name: TRK1 UnRedo - Executes undo/redo on TRK1
     value: 11
+    min: 0
+    max: 127
   - name: TRK2 Start - Play TRK2
     value: 12
+    min: 0
+    max: 127
   - name: TRK2 Stop - Stop TRK2
     value: 13
+    min: 0
+    max: 127
   - name: TRK2 UnRedo - Executes undo/redo on TRK2
     value: 14
+    min: 0
+    max: 127
   - name: Loop Level - Adjustes the looper plaback level
     value: 15
+    min: 0
+    max: 127
   - name: Total Level - Adjusts the playback of the rhythm and looper together
     value: 16
+    min: 0
+    max: 127
   - name: All Break - Breaks the Rhythm and looper together
     value: 17
+    min: 0
+    max: 127

--- a/data/brands/boss/rc10r.yaml
+++ b/data/brands/boss/rc10r.yaml
@@ -1,0 +1,55 @@
+midi_in: TRS
+midi_clock: Yes
+
+midi_channel:
+  instructions: |+
+    The RC-10R ships with the default MIDI control channel of 1 and a Note channel of 10. 
+    The note channel is for playing the drum sounds via MIDI. 
+    MIDI CC commands are OFF by default. You need to program the unit with the CC per command. The CC numbers below are just suggestions. CC can be 1-31 and 64-95.
+    In other words, if you just send the commands below nothing will happen. You need to set the CC value for each command on the RC-10R. 
+    MIDI note mapping is found on the last page the RC-10R MIDI implimentation guide.
+pc:
+  description: |+
+    PC#1 (00H) activates Memory 1
+    PC#2 (01H) activates Memory 2
+    etc
+    can transmit Program Changes from the RC-10R by enabling PC IN/OUT.
+cc:
+  - name: Rhy Start CC - Start the rhythm
+    value: 1
+    description: '1-95'
+    type: Parameter
+    min: 0
+    max: 95
+  - name: Rhy Division - Switch rhythm between PTN1 and PTN2
+    value: 2
+  - name: Rhy Fillin - Play a fill-in
+    value: 3
+  - name: Rhy Stop - Stops the rhythm
+    value: 4
+  - name: Rhy Break - Break the rhythm playback
+    value: 5
+  - name: Rhy Level - Adjust the rhythm playback level
+    value: 6
+  - name: Loop Start - Start the Looper
+    value: 7
+  - name: Loop Stop - Stop the Looper
+    value: 8
+  - name: TRK1 Start - Play TRK1
+    value: 9
+  - name: TRK1 Stop - Stop TRK1
+    value: 10
+  - name: TRK1 UnRedo - Executes undo/redo on TRK1
+    value: 11
+  - name: TRK2 Start - Play TRK2
+    value: 12
+  - name: TRK2 Stop - Stop TRK2
+    value: 13
+  - name: TRK2 UnRedo - Executes undo/redo on TRK2
+    value: 14
+  - name: Loop Level - Adjustes the looper plaback level
+    value: 15
+  - name: Total Level - Adjusts the playback of the rhythm and looper together
+    value: 16
+  - name: All Break - Breaks the Rhythm and looper together
+    value: 17

--- a/data/brands/line6/powercab.yaml
+++ b/data/brands/line6/powercab.yaml
@@ -1,0 +1,181 @@
+midi_in: DIN5
+midi-thru: Yes
+
+midi_channel:
+  instructions: |+
+    Line 6 Powercab 112 Plus and 212 Plus have MIDI. The Powercab does not. The covers both Pus models.  Speaker 2 does not apply to the 112.
+pc:
+  description: |+
+    PC#1 (00H) recalls preset 0
+    PC#2 (01H) recalls preset 1
+    etc through 127
+   
+cc:
+  - name: Input 1/L Gain
+    value: 1
+    description: 'Adjustable input gain level for Input 1 (Left/Mono). 113 = 0.0dB'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input 1/L Level
+    value: 30
+    description: 'Input level and impedance. 0-63: Line, 64-127: Instrument'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input 2/R Gain
+    value: 2
+    description: 'Adjustable input gain level for Input 2 (Right/Aux). 113 = 0.0dB'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input 2/R Level
+    value: 31
+    description: 'Input level and impedance. 0-63: Line, 64-127: Instrument'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Input 2/R Mode
+    value: 3
+    description: '0-4 0: Normal (Processes input and routes signal through the XLR Output.), 41-80: Monitor (No processing, no XLR out), 81-127: USB (Input 2 is routed to the USB 1/2 input and can be used with guitar amp modeling software like Helix Native.)'
+    type: Parameter
+    min: 0
+    max: 4
+  - name: Link Inputs
+    value: 4
+    description: '0-63: Off, 64-127: On'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: HF Trim
+    value: 5
+    description: 'Gain adjustment for the high frequency compression driver'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Low Cut
+    value: 111
+    description: 'Applies a global 80 Hz low cut (high pass filter) to speaker. 0-63: Off, 64-127: On. Suspect this only applies to the 212. The 112 has a switch on the back.'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: USB Mode
+    value: 6
+    description: '0-63: Normal (for FRFR), 64-127: Processes the USB signal with Flat, Speaker, or User IR modes.'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Mode
+    value: 20
+    description: '0 = Flat, 1 = Speaker, 2 = User IR, 3 = Dual Speaker (212), 4 = Dual User IR (212)'
+    type: Parameter
+    min: 0
+    max: 4
+  - name: Voicing
+    value: 21
+    description: '0 = FRFR, 1 = LF Flat, 2 = LF Raw'
+    type: Parameter
+    min: 0
+    max: 2
+  - name: Speaker 1
+    value: 22
+    description: '0 = Vintage, 1 = Green, 2 = Cream, 3 = Jarvis, 4 = Bayou, 5 = Essex, 6 = Natural, 7 = Dino, 8 = Lecto, 9 = Herald, 10 = Brown, 11 = Shade, 12 = Jetson'
+    type: Parameter
+    min: 0
+    max: 12
+  - name: Mic Model 1
+    value: 23
+    description: '0 = 57 Dyn, 1 = 409 Dyn, 2 = 421 Dyn, 3 = 30 Dyn, 4 = 20 Dyn, 5 = 121 Ribbon, 6 = 160 Ribbon, 7 = 4038 Ribbon, 8 = 414 Cond, 9 = 84 Cond, 10 = 67 Cond, 11 = 87 Cond, 12 = 47 Cond, 13 = 112 Dyn, 14 = 12 Dyn, 15 = 7 Dyn'
+    type: Parameter
+    min: 0
+    max: 15
+  - name: Mic Distance 1
+    value: 24
+    description: 'Mic distance in 1/2" increments'
+    type: Parameter
+    min: 0
+    max: 22
+  - name: IR 1
+    value: 25
+    description: 'Which User IR is on speaker 1'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Low Cut 1
+    value: 26
+    description: '20Hz - 500Hz'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: High Cut 1
+    value: 27
+    description: '500Hz - 20kHz'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Level 1
+    value: 28
+    description: 'Controls the volume of the current preset and can be adjusted to match levels between presets. When an IR is in use, the default is -18.0dB to compensate for the higher amplitude common to IR files. When the Flat Mode is in use, this is set to 0.0dB for maximum headroom.'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Color 1
+    value: 29
+    description: '0 = Off, 1–18 = White, 19–36 = Red, 37–54 = Blue, 55–72 = Green, 73–90 = Yellow, 91–108 = Cyan, 109–126 = Magenta, 127 = Auto'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Speaker 2
+    value: 102
+    description: '0 = Vintage, 1 = Green, 2 = Cream, 3 = Jarvis, 4 = Bayou, 5 = Essex, 6 = Natural, 7 = Dino, 8 = Lecto, 9 = Herald, 10 = Brown, 11 = Shade, 12 = Jetson'
+    type: Parameter
+    min: 0
+    max: 12
+  - name: Mic Model 2
+    value: 103
+    description: '0 = 57 Dyn, 1 = 409 Dyn, 2 = 421 Dyn, 3 = 30 Dyn, 4 = 20 Dyn, 5 = 121 Ribbon, 6 = 160 Ribbon, 7 = 4038 Ribbon, 8 = 414 Cond, 9 = 84 Cond, 10 = 67 Cond, 11 = 87 Cond, 12 = 47 Cond, 13 = 112 Dyn, 14 = 12 Dyn, 15 = 7 Dyn'
+    type: Parameter
+    min: 0
+    max: 15
+  - name: Mic Distance 2
+    value: 104
+    description: 'Mic distance in 1/2" increments'
+    type: Parameter
+    min: 0
+    max: 22
+  - name: IR 2
+    value: 105
+    description: 'Which User IR is on speaker 1'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Low Cut 2
+    value: 106
+    description: '20Hz - 500Hz'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: High Cut 2
+    value: 107
+    description: '500Hz - 20kHz'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Level 2
+    value: 108
+    description: 'Controls the volume of the current preset and can be adjusted to match levels between presets. When an IR is in use, the default is -18.0dB to compensate for the higher amplitude common to IR files. When the Flat Mode is in use, this is set to 0.0dB for maximum headroom.'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Color 2
+    value: 109
+    description: '0 = Off, 1–18 = White, 19–36 = Red, 37–54 = Blue, 55–72 = Green, 73–90 = Yellow, 91–108 = Cyan, 109–126 = Magenta, 127 = Auto'
+    type: Parameter
+    min: 0
+    max: 127
+  - name: Stereo Width
+    value: 110
+    description: 'Collapses to mono at 0%, nominal at 100%, and extra wide at 200%. 50 = 100%, 100 = 200%'
+    type: Parameter
+    min: 0
+    max: 100

--- a/data/mapping.json
+++ b/data/mapping.json
@@ -15,13 +15,28 @@
             ]
         },
         {
+            "name": "Behringer",
+            "value": "behringer",
+            "models": [
+                {
+                    "name": "X-Air",
+                    "value": "xair"
+                }
+            ]
+        },
+        {
             "name": "Boss",
             "value": "boss",
             "models": [
                 {
                     "name": "Katana",
                     "value": "katana"
+                },
+                {
+                    "name": "RC-10R",
+                    "value": "rc10r"
                 }
+  
             ]
         },
         {
@@ -217,7 +232,12 @@
                 {
                     "name": "Helix Floor",
                     "value": "helixfloor"
+                },
+                {
+                    "name": "Powercab Plus",
+                    "value": "powercab"
                 }
+
             ]
         },
         {


### PR DESCRIPTION
Added Line 6 PowerCab Plus, Behringer X-Air mixer, and the Boss RC-10R.

Couple of places to review: 

1. The PowerCab supports the Plus 112 and the Plus 212.  There are a few extra parameters for the 212's extra speaker. But I think it is fairly clear and doesn't need two separate devices.
2. Same with the X-Air. It supports the 12, 16, and 18 mixers. Obviously channels higher that your model number are not supported. i.e. changing the fader on channel 13 will have no effect on the X-Air 12.
3. The X-Air is a bit unique in that sending the same CC on channel 1, 2, or 3 has a related action. Channel 1 controls the fader, 2 the mute, and 3 the PAN. I took a stab at how best to handle this, but am open to a better way.