### PR TITLE
Fix missing min and max value for HXStompXl

### DIFF
--- a/data/brands/line6/hxstompxl.yaml
+++ b/data/brands/line6/hxstompxl.yaml
@@ -199,8 +199,8 @@ cc:
     value: 71
     description: ''
     type: System
-    min: 0
-    max: 0
+    min: 64
+    max: 127
   - name: Increment Preset
     value: 72
     description: ''
@@ -217,5 +217,5 @@ cc:
     value: 73
     description: ''
     type: System
-    min: 0
-    max: 0
+    min: 64
+    max: 127


### PR DESCRIPTION
Min value was set to 64 and max value was set to 127 for 
 the Engage the Mode switch and toggle edit play view items.