### PR TITLE
Update Aeros & BB commands, add Amplifire, suggest better yaml linter, document cc type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Special thanks to all who have contributed!
 - [Harris Novick](https://github.com/lightyrs)
 
 # How to contribute
-## If you are inclined to contribute via Github
+## If you are inclined to contribute via GitHub
 1. Fork the repository
 2. Add your changes
    - Create a new yaml file
-     - Check that your YAML file is valid: http://www.yamllint.com/
+     - Check that your YAML file is valid: http://www.yamllint.com/ (or https://codebeautify.org/yaml-validator)
    - Update `mapping.json` file
      - Check that your JSON updates are valid: https://jsonlint.com/
    
@@ -64,7 +64,7 @@ After a new yaml file is created, the `mapping.json` file needs to be updated to
       - name: [CC Function Name]
         value: [CC Number 0 - 127]
         description: [Description of function]
-        type: [Parameter | System]
+        type: [Parameter | System] # Note: Parameter is a value to change (e.g., volume). System is a command to the device.
         min: [Minimum CC Value]
         max: [ Maximum CC Value]
 

--- a/data/brands/atomic/amplifire.yaml
+++ b/data/brands/atomic/amplifire.yaml
@@ -1,0 +1,249 @@
+midi_in: DIN5
+midi_thru: Yes
+phantom_power: Yes
+midi_clock: Yes
+
+midi_channel:
+  instructions: |
+   PC Data Values between 0 and 63 are interpreted as OFF. Values between 64 and 127 are interpreted as ON. For TAP TEMPO and FOOTSWITCH continuous controls, the DATA VALUE is ignored and any message is interpreted as a “press” of that function.
+
+   CC value assignments are configurable to modify from these defaults.
+
+pc:
+  description:  Activates the preset at the OC value MIDI PROGRAM CHANGES are mapped one-to-one, meaning that AMPLIFIRE will switch to the same preset as the incoming MIDI program change message . Likewise, if you change presets in AMPLIFIRE using the ENCODER or FOOTSWITCH, AMPLIFIRE will transmit the same preset number in the outgoing MIDI program change.
+
+cc:
+  - value: 21
+    name: Wah Pedal Enable
+    description: Wah Pedal
+    max: 127
+    min: 0
+    type: system
+  - value: 22
+    name: Volume Pedal Enable
+    description: Volume Pedal
+    max: 127
+    min: 0
+    type: system
+  - value: 23
+    name: Expression A
+    description: Expression A
+    max: 127
+    min: 0
+    type: parameter
+  - value: 24
+    name: Expression B
+    description: Expression B
+    max: 127
+    min: 0
+    type: parameter
+  - value: 18
+    name: Tap Tempo Press
+    description: Tap Tempo Press
+    max: 127
+    min: 0
+    type: system
+  - value: 80
+    name: Bypass Amplifire
+    description: Bypass Amplifire
+    max: 127
+    min: 0
+    type: system
+  - value: 81
+    name: Effect Loop Enable
+    description: Effect Loop Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 20
+    name: Volume Enable
+    description: Volume Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 19
+    name: Wah Enable
+    description: Wah Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 82
+    name: Boost Enable
+    description: Boost Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 83
+    name: Effect Enable
+    description: Effect Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 25
+    name: Chorus Enable
+    description: Chorus Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 26
+    name: Flanger Enable
+    description: Flanger Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 27
+    name: Phaser Enable
+    description: Phaser Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 28
+    name: Tremolo Enable
+    description: Tremolo Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 29
+    name: Pitchshifter Enable
+    description: Pitchshifter Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 84
+    name: Echo Enable
+    description: Echo Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 85
+    name: Reverb Enable
+    description: Reverb Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 86
+    name: Noise Gate enable
+    description: Noise Gate enable
+    max: 127
+    min: 0
+    type: system
+  - value: 17
+    name: Compressor Enable
+    description: Compressor Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 87
+    name: Graphic Eq enable
+    description: Graphic Eq enable
+    max: 127
+    min: 0
+    type: system
+  - value: 12
+    name: Pre-Eq enable
+    description: Pre-Eq enable
+    max: 127
+    min: 0
+    type: system
+  - value: 88
+    name: Parametric #1 enable
+    description: Parametric #1 enable
+    max: 127
+    min: 0
+    type: system
+  - value: 89
+    name: Parametric #2 enable
+    description: Parametric #2 enable
+    max: 127
+    min: 0
+    type: system
+  - value: 90
+    name: Parametric #3 enable
+    description: Parametric #3 enable
+    max: 127
+    min: 0
+    type: system
+  - value: 16
+    name: Amp Enable
+    description: Amp Enable
+    max: 127
+    min: 0
+    type: system
+  - value: 13
+    name: FS1 Press
+    description: FS1 Press
+    max: 127
+    min: 0
+    type: system
+  - value: 14
+    name: FS2 Press
+    description: FS2 Press
+    max: 127
+    min: 0
+    type: system
+  - value: 15
+    name: FS3 Press
+    description: FS3 Press
+    max: 127
+    min: 0
+    type: system
+  - value: 11
+    name: FS4 Press (AA12 only)
+    description: FS4 Press (AA12 only)
+    max: 127
+    min: 0
+    type: system
+  - value: 10
+    name: FS5 Press (AA12 only)
+    description: FS5 Press (AA12 only)
+    max: 127
+    min: 0
+    type: system
+  - value: 9
+    name: FS6 Press (AA12 only)
+    description: FS6 Press (AA12 only)
+    max: 127
+    min: 0
+    type: system
+  - value: 8
+    name: FS7 Press 
+    description: FS7 Press 
+    max: 127
+    min: 0
+    type: system
+  - value: 7
+    name: FS8 Press 
+    description: FS8 Press 
+    max: 127
+    min: 0
+    type: system
+  - value: 6
+    name: FS9 Press 
+    description: FS9 Press 
+    max: 127
+    min: 0
+    type: system
+  - value: 5
+    name: FS0 Press 
+    description: FS0 Press 
+    max: 127
+    min: 0>
+    type: system
+  - value: 4
+    name: FS+ Press 
+    description: FS+ Press (AA12 only)
+    max: 127
+    min: 0
+    type: system
+  - value: 3
+    name: FS- Press 
+    description: FS- Press (AA12 only)
+    max: 127
+    min: 0
+    type: system
+  - value: 84
+    name: Echo Enable
+    description: Echo Enable
+    max: 127
+    min: 0
+    type: system

--- a/data/brands/singular_sound/aeros_looper.yaml
+++ b/data/brands/singular_sound/aeros_looper.yaml
@@ -1,6 +1,6 @@
 midi_in: DIN5
 midi_thru: Yes
-phantom_power: yes
+phantom_power: Yes
 midi_clock: Yes
 
 midi_channel:

--- a/data/brands/singular_sound/aeros_looper.yaml
+++ b/data/brands/singular_sound/aeros_looper.yaml
@@ -4,7 +4,7 @@ phantom_power: Yes
 midi_clock: Yes
 
 midi_channel:
-  instructions: >
+  instructions: |
     Sysex Info:
 
     Start (Sysex Real Time)	- Starts the Aeros depending on the MIDI Start setting. If the part is empty and MIDI Start is set to record, the Aeros will

--- a/data/brands/singular_sound/aeros_looper.yaml
+++ b/data/brands/singular_sound/aeros_looper.yaml
@@ -47,69 +47,69 @@ cc:
     max: 0
     min: 0
     name: Save song
-    type: null
+    type: system
     value: 33
   - description: Start new 2x2 song (same settings as previously loaded 2x2 song) and
       enter loop studio
     max: 0
     min: 0
     name: Start new 2x2 song
-    type: null
+    type: system
     value: 34
   - description: Start new 6x6 song (same settings as previously loaded 6x6 song) and
       enter loop studio
     max: 1
     min: 1
     name: Start new 6x6 song
-    type: null
+    type: system
     value: 34
   - description: Go to saved songs screen (show currently loaded song)
     max: 0
     min: 0
     name: Go to saved songs screen
-    type: null
+    type: system
     value: 35
   - description: Go to Loop Studio screen (if already in Loop Studio screen, ignore)
     max: 1
     min: 1
     name: Go to Loop Studio screen
-    type: null
+    type: system
     value: 35
   - description: Go to Home screen.  Added in 4.1.2
     max: 2
     min: 2
     name: Go to Home screen
-    type: null
+    type: system
     value: 35
   - description: Go to Device Setting screen.  Added in 4.1.2
     max: 3
     min: 3
     name: Go to Device Setting screen
-    type: null
+    type: system
     value: 35
   - description: Go to Updates screen.  Added in 4.1.2
     max: 4
     min: 4
     name: Go to Updates screen
-    type: null
+    type: system
     value: 35
   - description: Scroll down list (songs screen, or otherwise if relevant)
     max: 0
     min: 0
     name: Scroll down list
-    type: null
+    type: system
     value: 36
   - description: Scroll up list (songs screen, or otherwise if relevant)
     max: 1
     min: 1
     name: Scroll up list
-    type: null
+    type: system
     value: 36
   - description: Select (currently highlighted item in song list)
     max: 2
     min: 2
     name: Select
-    type: null
+    type: system
     value: 36
   - description: |
         Starts the deletion confirmation dialog to delete a song in the Songs List.  Added in 4.1.2
@@ -117,233 +117,233 @@ cc:
     max: 3
     min: 3
     name: Delete Song from list
-    type: null
+    type: system
     value: 36
   - description: Goes to the top of the Songs List immediately. Added in 4.1.2
     max: 6
     min: 6
     name: Top of List
-    type: null
+    type: system
     value: 36
   - description: Goes to the bottom of the Songs List immediately. Added in 4.1.2
     max: 7
     min: 7
     name: Bottom of List
-    type: null
+    type: system
     value: 36
   - description: Undo/Redo currently selected track (6x6 mode)
     max: 0
     min: 0
     name: Undo/Redo (6x6 mode)
-    type: null
+    type: system
     value: 37
   - description: 'Undo/Redo track (value #)'
     max: 6
     min: 1
     name: Undo/Redo track
-    type: null
+    type: system
     value: 37
   - description: 'Mutes/Unmutes track depending on current state (track # = value #)'
     max: 6
     min: 1
     name: Mute/Unmute Toggle
-    type: null
+    type: system
     value: 38
   - description: 'Mutes track, follows the global Mute Settings (track # = value # - 10).  Added in 4.1.2'
     max: 16
     min: 11
     name: Mute Track per global setting
-    type: null
+    type: system
     value: 38
   - description: 'UnMutes track, follows the global Mute Settings (track # = value # - 20).  Added in 4.1.2'
     max: 26
     min: 21
     name: UnMute Track per global setting
-    type: null
+    type: system
     value: 38
   - description: 'Mutes track at End of Loop (track # = value # - 30).  Added in 4.1.2'
     max: 36
     min: 31
     name: Mute Track at EOL
-    type: null
+    type: system
     value: 38
   - description: 'UnMutes track at End of Loop (track # = value # - 40).  Added in 4.1.2'
     max: 46
     min: 41
     name: UnMute Track at EOL
-    type: null
+    type: system
     value: 38
   - description: 'Mute track at End of Measure (track # = value # - 50).  Added in 4.1.2'
     max: 56
     min: 51
     name: UnMute Track at EOM
-    type: null
+    type: system
     value: 38
   - description: 'UnMute track at End of Measure (track # = value # - 60).  Added in 4.1.2'
     max: 66
     min: 61
     name: UnMute Track at EOM
-    type: null
+    type: system
     value: 38
   - description: 'Mute track Immediately (track # = value # - 70).  Added in 4.1.2'
     max: 76
     min: 71
     name: Mute track Immediately
-    type: null
+    type: system
     value: 38
   - description: 'UnMute track Immediately, follows the global Mute Settings (track # = value # - 80).  Added in 4.1.2'
     max: 86
     min: 81
     name: UnMute Track Immediately
-    type: null
+    type: system
     value: 38
   - description: 'Unmutes all tracks, follows global mute settings.  Added in 3.0.0'
     max: 127
     min: 127
     name: UnMute all Tracks per global setting
-    type: null
+    type: system
     value: 38
   - description: Stop playback immediately
     max: 0
     min: 0
     name: Stop
-    type: null
+    type: system
     value: 39
   - description: 'Solos track (track # = value #). This behaves like a XOR solo function, only one track can be soloed at a time in a given song part. Added in 3.0.0'
     max: 6
     min: 1
     name: Solo
-    type: null
+    type: system
     value: 39
   - description: 'Un-solos track, this unmutes all other tracks in the song part. Added in 3.0.0'
     max: 127
     min: 127
     name: UnSolo
-    type: null
+    type: system
     value: 39
   - description: Record new song part (6x6)
     max: 0
     min: 0
     name: Record new song part
-    type: null
+    type: system
     value: 40
   - description: Record new track (6x6).  Begins or sets up a recording on the next available empty track, if no tracks are left to record to in a part, it will be ignored. In 6x6, if a new part is selected, this command will start or set up a recording in the new part. If recording to the last track in a part, sending this command will commit the current recording. If there is an undone track and all other tracks are recorded to, this command will record to the next available undone track in order.
     max: 0
     min: 0
     name: Record new track
-    type: null
+    type: system
     value: 41
   - description: This commits any current recording or overdub and goes into playback mode. Added in 4.0.0
     max: 20
     min: 20
     name: Commit Recording
-    type: null
+    type: system
     value: 41
   - description: Record/Play/Overdub on selected track (6x6)	 Added in 4.1.2
     max: 100
     min: 100
     name: RPO Selected
-    type: null
+    type: system
     value: 41
   - description: Record/Play/Overdub on Track 1	 Added in 4.1.2
     max: 101
     min: 101
     name: RPO 1
-    type: null
+    type: system
     value: 41
   - description: Record/Play/Overdub on Track 2	 Added in 4.1.2
     max: 102
     min: 102
     name: RPO 2
-    type: null
+    type: system
     value: 41
   - description: 'Clears the song (deletes all tracks) with no confirmation when the looper is stopped and in the Loop Studio screen. Note: You CANNOT undo this action. Added in 4.0.0'
     max: 0
     min: 0
     name: Clear Song Immediately
-    type: null
+    type: system
     value: 42
   - description: 'Stop'
     max: 0
     min: 0
     name: Stop
-    type: null
+    type: system
     value: 43
   - description: 'Start'
     max: 1
     min: 1
     name: Stop
-    type: null
+    type: system
     value: 43
   - description: 'Cancel Stop'
     max: 2
     min: 2
     name: Cancel Stop
-    type: null
+    type: system
     value: 43
   - description: 'Stop Immediately'
     max: 127
     min: 127
     name: Stop Immediately
-    type: null
+    type: system
     value: 43
   - description: 'Sets the Action buttons in 2x2 and 6x6 to Record, Play, Overdub. This means that the Aeros will first start/set-up playback and then give the option to overdub. If recordings can be committed immediately, the Aeros will enter playback once the action button is pressed.	Added in 4.1.2'
     max: 0
     min: 0
     name: Set RPO
-    type: null
+    type: system
     value: 45
   - description: 'Changes song parts in 2x2 immediately. In 6x6, it will change song parts if a different song part than the one currently playing is selected. Please note: This command overrides the ‘Change Parts: End of Loop’ setting. This command is sent by the BeatBuddy by default when it changes parts. If currently recording, the Aeros will respect any Sync rules and/or finish the measure (in quantized mode).		Added in 4.1.2'
     max: 0
     min: 0
     name: Set ROP
-    type: null
+    type: system
     value: 45
   - description: 'Changes song parts in 2x2 immediately. In 6x6, it will change song parts if a different song part than the one currently playing is selected. Please note: This command overrides the ‘Change Parts: End of Loop’ setting. This command is sent by the BeatBuddy by default when it changes parts. If currently recording, the Aeros will respect any Sync rules and/or finish the measure (in quantized mode). Added in 3.0.0'
     max: 32
     min: 1
     name: Next Part Immediately
-    type: null
+    type: system
     value: 102
   - description: "Starts transition to the currently selected part in 6x6. This command is used in conjunction with CC113 values 126 and 127 to allow toggling through parts before starting the transition. This is not needed in 2x2.	 Added in 4.1.2"
     max: 0
     min: 0
     name: Transition to Selected Part
-    type: null
+    type: system
     value: 113
   - description: "Begin the transition to part (part # = value #) according to the Change Part setting (Immediately/End of Measure/End of Loop). If using the BeatBuddy, the CC:102 command will override this command. If the part doesn't exist in the song, the Aeros will ignore the command. This command cannot start the Aeros from a stopped state.	Added in 3.0.0"
     max: 6
     min: 1
     name: Change Part
-    type: null
+    type: system
     value: 113
   - description: "Value 101-106: Begin the transition to part (part # = value # minus 100 , so value 102 is part 2) according to the Change Part setting (Immediately/End of Measure/End of Loop). If the part doesn’t exist in the song, the Aeros will ignore the command. This allows you to send a single on-press command for changing parts. This also allows you to switch the part on the Aeros without switching parts on the BeatBuddy (which ignores values 101-106) when they are on the same channel and being controlled by a MIDI controller. This command can start the Aeros from a stopped state. Added in 4.1.2"
     max: 106
     min: 101
     name: Change Part (Aeros Only)
-    type: null
+    type: system
     value: 113
   - description: "Cancels any pending transition. Added in 4.1.2"
     max: 125
     min: 125
     name: Cancel Transition
-    type: null
+    type: system
     value: 113
   - description: "In 2x2, this will start the transition to the previous part. In 6x6, this will toggle through the available parts from bottom to top. To switch to the selected part, the user must send CC113 value 0 to start the transition. Added in 4.1.2"
     max: 126
     min: 126
     name: Prev Part
-    type: null
+    type: system
     value: 113
   - description: "In 2x2, this will start the transition to the next part. In 6x6, this will toggle through the available parts from top to bottom. To switch to the selected part, the user must send CC113 value 0 to start the transition. Added in 4.1.2"
     max: 127
     min: 127
     name: Next Part
-    type: null
+    type: system
     value: 113
   - description: "Will save a screenshot of the current Aeros screen to the SD card. Note: Must have SD card inserted in Aeros.	 Added in 3.0.0"
     max: 127
     min: 127
     name: Screenshot
-    type: null
+    type: system
     value: 127

--- a/data/brands/singular_sound/aeros_looper.yaml
+++ b/data/brands/singular_sound/aeros_looper.yaml
@@ -4,21 +4,46 @@ phantom_power: No
 midi_clock: Yes
 
 midi_channel:
-  instructions: |+
+  instructions: >
+    Sysex Info:
 
+    Start (Sysex Real Time)	- Starts the Aeros depending on the MIDI Start setting. If the part is empty and MIDI Start is set to record, the Aeros will
+    record on the first track. If the song part is empty and the MIDI Start setting is set to only playback, the Aeros will enter a 'scrolling' mode in the empty part.
+
+    Stop (Sysex Real Time) - Stops playback immediately
+
+    Time Signature:	- Time Signature is sent by BeatBuddy whenever a song is loaded as a Sysex midi message and repeatedly every 3 seconds. The Aeros will set it's own internal time signature when receiving these commands if the song is empty.
+        (All values in hex)
+        2/4: F0 - 7F - 7F - 03 - 02 - 04 - 02 - 02 - 18 - 08 - F7
+        3/4: F0 - 7F - 7F - 03 - 02 - 04 - 03 - 02 - 18 - 08 - F7
+        4/4: F0 - 7F - 7F - 03 - 02 - 04 - 04 - 02 - 18 - 08 - F7
+        5/4: F0 - 7F - 7F - 03 - 02 - 04 - 05 - 02 - 18 - 08 - F7
+        3/8: F0 - 7F - 7F - 03 - 02 - 04 - 03 - 03 - 18 - 08 - F7
+        6/8: F0 - 7F - 7F - 03 - 02 - 04 - 06 - 03 - 18 - 08 - F7
 
 pc:
-  description: |+
+  description: |
+    The Aeros can open any song using a combination of MSB and PC commands.  Added in 4.1.2
+
+    MSB value 0-127
+    PC value 0-12
+
+    Pay close attention this is a brain twister: MSB stands for Most Significant Bit, it is a concept used in MIDI that allows a user to do all sorts of things like change parameters, change banks, and—in the Aeros' case—song select .
+
+    MSB is not a traditional MIDI command, it is actually activated by using a CC:0 (Control Change) command, the value decides which MSB bank is chosen. So, CC:0 value 4 represents MSB bank 4.
+
+    PC (Program Change) is another type of MIDI command typically used in conjunction with MSB and/or LSB commands. LSB (Least Significant Bit; CC:32 values 0-127) is not relevant to the Aeros, but is relevant to the BeatBuddy's song select scheme. It is often also used without an MSB (CC:0) and/or LSB (CC:32) command, but that is not the case for the Aeros.
+
+    The Aeros requires the user to send an MSB + and a PC command—in that order—to open a song.
+
+    First, the user must open the song, and edit the song. Then, you will find the MIDI song Select enabled setting. Once enabled, the user can set which MSB (0-127) bank and which PC command will be required to open the song.
+
+    Then, using a MIDI controller capable of sending CC:0 (MSB) + PC commands in a sequence, you can open that song at any time.
+
+    KNOWN BUG v4.1.2: Aeros is currently not responding to commands sent in the Home Screen before a song has been opened, you must open a song before the Aeros can register the commands and open a song via MIDI select.
 
 cc:
-  - description: This triggers changing song parts to the selected part in 6x6, or the
-      part not currently playing in 2x2
-    max: 127
-    min: 1
-    name: Next part
-    type: null
-    value: 102
-  - description: null
+  - description: Saves the currently open Aeros song if a change was made since last saved and the Aeros is currently stopped. Added in 3.0.0
     max: 0
     min: 0
     name: Save song
@@ -50,6 +75,24 @@ cc:
     name: Go to Loop Studio screen
     type: null
     value: 35
+  - description: Go to Home screen.  Added in 4.1.2
+    max: 2
+    min: 2
+    name: Go to Home screen
+    type: null
+    value: 35
+  - description: Go to Device Setting screen.  Added in 4.1.2
+    max: 3
+    min: 3
+    name: Go to Device Setting screen
+    type: null
+    value: 35
+  - description: Go to Updates screen.  Added in 4.1.2
+    max: 4
+    min: 4
+    name: Go to Updates screen
+    type: null
+    value: 35
   - description: Scroll down list (songs screen, or otherwise if relevant)
     max: 0
     min: 0
@@ -68,6 +111,26 @@ cc:
     name: Select
     type: null
     value: 36
+  - description: |
+        Starts the deletion confirmation dialog to delete a song in the Songs List.  Added in 4.1.2
+        KNOWN ISSUE v4.1.2: The Aeros does not have a pop-up confirmation or cancellation MIDI command, the user would still have to use the physical buttons on the Aeros to confirm/cancel a deletion dialog.
+    max: 3
+    min: 3
+    name: Delete Song from list
+    type: null
+    value: 36
+  - description: Goes to the top of the Songs List immediately. Added in 4.1.2
+    max: 6
+    min: 6
+    name: Top of List
+    type: null
+    value: 36
+  - description: Goes to the bottom of the Songs List immediately. Added in 4.1.2
+    max: 7
+    min: 7
+    name: Bottom of List
+    type: null
+    value: 36
   - description: Undo/Redo currently selected track (6x6 mode)
     max: 0
     min: 0
@@ -80,10 +143,64 @@ cc:
     name: Undo/Redo track
     type: null
     value: 37
-  - description: 'Mutes/Unmutes track (value #)'
+  - description: 'Mutes/Unmutes track depending on current state (track # = value #)'
     max: 6
     min: 1
-    name: Mute/Unmute
+    name: Mute/Unmute Toggle
+    type: null
+    value: 38
+  - description: 'Mutes track, follows the global Mute Settings (track # = value # - 10).  Added in 4.1.2'
+    max: 16
+    min: 11
+    name: Mute Track per global setting
+    type: null
+    value: 38
+  - description: 'UnMutes track, follows the global Mute Settings (track # = value # - 20).  Added in 4.1.2'
+    max: 26
+    min: 21
+    name: UnMute Track per global setting
+    type: null
+    value: 38
+  - description: 'Mutes track at End of Loop (track # = value # - 30).  Added in 4.1.2'
+    max: 36
+    min: 31
+    name: Mute Track at EOL
+    type: null
+    value: 38
+  - description: 'UnMutes track at End of Loop (track # = value # - 40).  Added in 4.1.2'
+    max: 46
+    min: 41
+    name: UnMute Track at EOL
+    type: null
+    value: 38
+  - description: 'Mute track at End of Measure (track # = value # - 50).  Added in 4.1.2'
+    max: 56
+    min: 51
+    name: UnMute Track at EOM
+    type: null
+    value: 38
+  - description: 'UnMute track at End of Measure (track # = value # - 60).  Added in 4.1.2'
+    max: 66
+    min: 61
+    name: UnMute Track at EOM
+    type: null
+    value: 38
+  - description: 'Mute track Immediately (track # = value # - 70).  Added in 4.1.2'
+    max: 76
+    min: 71
+    name: Mute track Immediately
+    type: null
+    value: 38
+  - description: 'UnMute track Immediately, follows the global Mute Settings (track # = value # - 80).  Added in 4.1.2'
+    max: 86
+    min: 81
+    name: UnMute Track Immediately
+    type: null
+    value: 38
+  - description: 'Unmutes all tracks, follows global mute settings.  Added in 3.0.0'
+    max: 127
+    min: 127
+    name: UnMute all Tracks per global setting
     type: null
     value: 38
   - description: Stop playback immediately
@@ -92,28 +209,141 @@ cc:
     name: Stop
     type: null
     value: 39
+  - description: 'Solos track (track # = value #). This behaves like a XOR solo function, only one track can be soloed at a time in a given song part. Added in 3.0.0'
+    max: 6
+    min: 1
+    name: Solo
+    type: null
+    value: 39
+  - description: 'Un-solos track, this unmutes all other tracks in the song part. Added in 3.0.0'
+    max: 127
+    min: 127
+    name: UnSolo
+    type: null
+    value: 39
   - description: Record new song part (6x6)
     max: 0
     min: 0
     name: Record new song part
     type: null
     value: 40
-  - description: Record new track (6x6)
+  - description: Record new track (6x6).  Begins or sets up a recording on the next available empty track, if no tracks are left to record to in a part, it will be ignored. In 6x6, if a new part is selected, this command will start or set up a recording in the new part. If recording to the last track in a part, sending this command will commit the current recording. If there is an undone track and all other tracks are recorded to, this command will record to the next available undone track in order.
     max: 0
     min: 0
     name: Record new track
     type: null
     value: 41
-  - description: "Begin transition to part (value #), if part does not exist in song, ignore command"
-    max: 6
-    min: 1
-    name: Begin transition
+  - description: This commits any current recording or overdub and goes into playback mode. Added in 4.0.0
+    max: 20
+    min: 20
+    name: Commit Recording
     type: null
-    value: 113
-  - description: Complete transition and change song parts at end of the bar (like on
-      BeatBuddy)
+    value: 41
+  - description: Record/Play/Overdub on selected track (6x6)	 Added in 4.1.2
+    max: 100
+    min: 100
+    name: RPO Selected
+    type: null
+    value: 41
+  - description: Record/Play/Overdub on Track 1	 Added in 4.1.2
+    max: 101
+    min: 101
+    name: RPO 1
+    type: null
+    value: 41
+  - description: Record/Play/Overdub on Track 2	 Added in 4.1.2
+    max: 102
+    min: 102
+    name: RPO 2
+    type: null
+    value: 41
+  - description: 'Clears the song (deletes all tracks) with no confirmation when the looper is stopped and in the Loop Studio screen. Note: You CANNOT undo this action. Added in 4.0.0'
     max: 0
     min: 0
-    name: Complete transition
+    name: Clear Song Immediately
+    type: null
+    value: 42
+  - description: 'Stop'
+    max: 0
+    min: 0
+    name: Stop
+    type: null
+    value: 43
+  - description: 'Start'
+    max: 1
+    min: 1
+    name: Stop
+    type: null
+    value: 43
+  - description: 'Cancel Stop'
+    max: 2
+    min: 2
+    name: Cancel Stop
+    type: null
+    value: 43
+  - description: 'Stop Immediately'
+    max: 127
+    min: 127
+    name: Stop Immediately
+    type: null
+    value: 43
+  - description: 'Sets the Action buttons in 2x2 and 6x6 to Record, Play, Overdub. This means that the Aeros will first start/set-up playback and then give the option to overdub. If recordings can be committed immediately, the Aeros will enter playback once the action button is pressed.	Added in 4.1.2'
+    max: 0
+    min: 0
+    name: Set RPO
+    type: null
+    value: 45
+  - description: 'Changes song parts in 2x2 immediately. In 6x6, it will change song parts if a different song part than the one currently playing is selected. Please note: This command overrides the ‘Change Parts: End of Loop’ setting. This command is sent by the BeatBuddy by default when it changes parts. If currently recording, the Aeros will respect any Sync rules and/or finish the measure (in quantized mode).		Added in 4.1.2'
+    max: 0
+    min: 0
+    name: Set ROP
+    type: null
+    value: 45
+  - description: 'Changes song parts in 2x2 immediately. In 6x6, it will change song parts if a different song part than the one currently playing is selected. Please note: This command overrides the ‘Change Parts: End of Loop’ setting. This command is sent by the BeatBuddy by default when it changes parts. If currently recording, the Aeros will respect any Sync rules and/or finish the measure (in quantized mode). Added in 3.0.0'
+    max: 32
+    min: 1
+    name: Next Part Immediately
+    type: null
+    value: 102
+  - description: "Starts transition to the currently selected part in 6x6. This command is used in conjunction with CC113 values 126 and 127 to allow toggling through parts before starting the transition. This is not needed in 2x2.	 Added in 4.1.2"
+    max: 0
+    min: 0
+    name: Transition to Selected Part
     type: null
     value: 113
+  - description: "Begin the transition to part (part # = value #) according to the Change Part setting (Immediately/End of Measure/End of Loop). If using the BeatBuddy, the CC:102 command will override this command. If the part doesn't exist in the song, the Aeros will ignore the command. This command cannot start the Aeros from a stopped state.	Added in 3.0.0"
+    max: 6
+    min: 1
+    name: Change Part
+    type: null
+    value: 113
+  - description: "Value 101-106: Begin the transition to part (part # = value # minus 100 , so value 102 is part 2) according to the Change Part setting (Immediately/End of Measure/End of Loop). If the part doesn’t exist in the song, the Aeros will ignore the command. This allows you to send a single on-press command for changing parts. This also allows you to switch the part on the Aeros without switching parts on the BeatBuddy (which ignores values 101-106) when they are on the same channel and being controlled by a MIDI controller. This command can start the Aeros from a stopped state. Added in 4.1.2"
+    max: 106
+    min: 101
+    name: Change Part (Aeros Only)
+    type: null
+    value: 113
+  - description: "Cancels any pending transition. Added in 4.1.2"
+    max: 125
+    min: 125
+    name: Cancel Transition
+    type: null
+    value: 113
+  - description: "In 2x2, this will start the transition to the previous part. In 6x6, this will toggle through the available parts from bottom to top. To switch to the selected part, the user must send CC113 value 0 to start the transition. Added in 4.1.2"
+    max: 126
+    min: 126
+    name: Prev Part
+    type: null
+    value: 113
+  - description: "In 2x2, this will start the transition to the next part. In 6x6, this will toggle through the available parts from top to bottom. To switch to the selected part, the user must send CC113 value 0 to start the transition. Added in 4.1.2"
+    max: 127
+    min: 127
+    name: Next Part
+    type: null
+    value: 113
+  - description: "Will save a screenshot of the current Aeros screen to the SD card. Note: Must have SD card inserted in Aeros.	 Added in 3.0.0"
+    max: 127
+    min: 127
+    name: Screenshot
+    type: null
+    value: 127

--- a/data/brands/singular_sound/aeros_looper.yaml
+++ b/data/brands/singular_sound/aeros_looper.yaml
@@ -1,6 +1,6 @@
 midi_in: DIN5
 midi_thru: Yes
-phantom_power: No
+phantom_power: yes
 midi_clock: Yes
 
 midi_channel:

--- a/data/brands/singular_sound/beatbuddy.yaml
+++ b/data/brands/singular_sound/beatbuddy.yaml
@@ -10,35 +10,190 @@ midi_channel:
 pc:
   description: |+
 cc:
+  - description: Bank (Song Folder) Select MSB
+    max: 127
+    min: 0
+    name: Bank (Song Folder) Select MSB
+    type: system
+    value: 0
+  - description: Bank (Song folder) Select LSB
+    max: 127
+    min: 0
+    name: Bank (Song folder) Select LSB
+    type: system
+    value: 32
+  - description: Tempo Increment (NewTmpo = Tempo + value). Added 2.7.0
+    max: 127
+    min: 1
+    name: Tempo Increment
+    type: system
+    value: 80
+  - description: Tempo Decrement (NewTmpo = Tempo - value). Added 2.7.0
+    max: 127
+    min: 1
+    name: Tempo Decrement
+    type: system
+    value: 81
+  - description: Return to normal mode from Half Time. Added 2.7.0
+    max: 0
+    min: 0
+    name: Normal Time
+    type: system
+    value: 82
+  - description: Half Time. Added 2.7.0
+    max: 127
+    min: 1
+    name: Half Time
+    type: system
+    value: 82
+  - description: Return to normal mode from Double Time. Added 2.7.0
+    max: 0
+    min: 0
+    name: Normal Time
+    type: system
+    value: 83
+  - description: Double Time. Added 2.7.0
+    max: 127
+    min: 1
+    name: Double Time
+    type: system
+    value: 83
+  - description: 'Increase Tempo by 1. Also referred to as "Data increment (+1) or INC"'
+    max: 1
+    min: 1
+    name: Increase Tempo (or NRPN target) by 1
+    type: system
+    value: 96
+  - description: 'Decrease Tempo by 1. Also referred to as "Data decrement (-1) or  DEC"'
+    max: 1
+    min: 1
+    name: Decrease Tempo (or NRPN target) by 1
+    type: system
+    value: 97
+
+  - description: |
+      Set the NRPN LSB
+
+      We use the “NRPN Register” (Non-Registered Parameter Number) which is a
+      general purpose MSB (CC:99) and LSB (CC:98). All that means is that you can control
+      multiple parameters on the BeatBuddy using an MSB sequence, which is usually a
+      series of 3 commands: 2 CC commands and one PC.
+
+      This can be used to control tempo, any other parameter, or multiple parameters at
+      once. Currently we’re only using it to control tempo, but we follow the MIDI
+      Standard protocol to leave room for further control in the future.
+
+      Optional if the only value control by Inc/Dec is the Tempo. By
+      default, the Beatbuddy will increment / decrement the tempo when receiving a INC/
+      DEC message.
+    max: 107
+    min: 107
+    name: Set NRPN to Tempo LSB
+    type: system
+    value: 98
+  - description: Clear NRPN LSB Register
+    max: 127
+    min: 127
+    name: Clear NRPN LSB Register
+    type: system
+    value: 98
+  - description: |
+      Set the NRPN MSB
+
+      We use the “NRPN Register” (Non-Registered Parameter Number) which is a
+      general purpose MSB (CC:99) and LSB (CC:98). All that means is that you can control
+      multiple parameters on the BeatBuddy using an MSB sequence, which is usually a
+      series of 3 commands: 2 CC commands and one PC.
+
+      This can be used to control tempo, any other parameter, or multiple parameters at
+      once. Currently we’re only using it to control tempo, but we follow the MIDI
+      Standard protocol to leave room for further control in the future.
+
+      Optional if the only value control by Inc/Dec is the Tempo. By
+      default, the Beatbuddy will increment / decrement the tempo when receiving a INC/
+      DEC message.
+    max: 106
+    min: 106
+    name: Set NRPN to Tempo MSB
+    type: system
+    value: 99
+  - description: Clear NRPN MSB Register
+    max: 127
+    min: 127
+    name: Clear NRPN MSB Register
+    type: system
+    value: 99
+  - description: |
+      Set the Tempo MSB
+
+      In order to directly set the tempo to a specific BPM, you need to use the Tempo MSB and Tempo LSB. The Beatbuddy will update its current tempo only when receiving the LSB message.
+      - So the order of the message should be:
+        1. MSB value
+        2. LSB value
+      -  Don’t forget, the value of the Tempo can only be set with both MSB(CC:106) and LSB (CC:107).
+
+      The BeatBuddy's tempo range is from 40-300BPM
+    max: 127
+    min: 0
+    name: Tempo MSB
+    type: system
+    value: 106
+  - description:  |
+      Set the Tempo LSB
+
+      In order to directly set the tempo to a specific BPM, you need to use the Tempo MSB and Tempo LSB. The Beatbuddy will update its current tempo only when receiving the LSB message.
+      - So the order of the message should be:
+        1. MSB value
+        2. LSB value
+      -  Don’t forget, the value of the Tempo can only be set with both MSB(CC:106) and LSB (CC:107).
+
+      The BeatBuddy's tempo range is from 40-300BPM
+    max: 127
+    min: 0
+    name: Tempo LSB
+    type: system
+    value: 107
   - description: 'Change the Mixer Volume (Main Volume knob)'
     max: 100
     min: 0
     name: Mix Volume
-    type: null
+    type: parameter
     value: 108
   - description: Change the Headphone Volume
     max: 100
     min: 0
     name: Headphone Volume
-    type: null
+    type: parameter
     value: 109
   - description: 'Triggers an accent hit with a volume from the value 0 (mute) to 100 (original recorded volume) to 127 (amplified more than the original recorded volume)'
     max: 127
     min: 0
     name: Accent-Hit
-    type: null
+    type: system
     value: 110
-  - description: Pause / Unpause the current song
-    max: 127
+  - description: UnPause the current song
+    max: 0
+    min: 0
+    name: UnPause
+    type: system
+    value: 111
+  - description: Pause the current song
+    max: 1
     min: 1
-    name: Pause/Unpause
-    type: null
+    name: Pause
+    type: system
+    value: 111
+  - description: Toggle Pause/Unpause the current song
+    max: 127
+    min: 2
+    name: Pause Toggle
+    type: system
     value: 111
   - description: Triggers a drum fill
     max: 127
     min: 1
     name: Drum Fill
-    type: null
+    type: system
     value: 112
   - description: 'Starts song transition (selects the next part), 1: Starts transition,
       will jump to Part 1 on exit, 2: Starts transition, will jump to Part 2 on exit,
@@ -48,137 +203,66 @@ cc:
     max: 127
     min: 1
     name: Transition
-    type: null
+    type: system
+    value: 113
+  - description: 'Quits the transition and go to specified part'
+    max: 0
+    min: 0
+    name: End Transition
+    type: system
     value: 113
   - description: Starts the playback of the current song
     max: 127
     min: 1
     name: Start
-    type: null
+    type: system
     value: 114
   - description: Triggers the outro of the song
     max: 127
     min: 1
     name: Outro
-    type: null
+    type: system
     value: 115
   - description: Selects a specific drumset
     max: 127
     min: 1
     name: Select Drum Set
-    type: null
+    type: system
     value: 116
-  - description: null
+  - description: Enters Tap Tempo mode and generate Tap Event
     max: 127
     min: 0
     name: Tap Tempo
-    type: null
+    type: system
     value: 117
-  - description: null
-    max: 1
-    min: 1
-    name: Increase Tempo by 1
-    type: null
-    value: 96
-  - description: null
-    max: 1
-    min: 1
-    name: Decrease Tempo by 1
-    type: null
-    value: 97
-  - description: null
-    max: 106
-    min: 106
-    name: Set NRPN to Tempo MSB
-    type: null
-    value: 99
-  - description: null
-    max: 107
-    min: 107
-    name: Set NRPN to Tempo LSB
-    type: null
-    value: 98
-  - description: null
-    max: 127
-    min: 127
-    name: Clear NRPN MSB Register
-    type: null
-    value: 99
-  - description: null
-    max: 127
-    min: 127
-    name: Clear NRPN LSB Register
-    type: null
-    value: 98
-  - description: null
-    max: 127
-    min: 0
-    name: Bank (Song Folder) Select MSB
-    type: null
-    value: 0
-  - description: null
-    max: 127
-    min: 0
-    name: Bank (Song folder) Select LSB
-    type: null
-    value: 32
-  - description: null
-    max: 127
-    min: 1
-    name: "Data increment (+1) \u2013 INC"
-    type: null
-    value: 96
-  - description: null
-    max: 127
-    min: 1
-    name: "Data decrement (-1) \u2013 DEC"
-    type: null
-    value: 97
-  - description: null
-    max: 127
-    min: 0
-    name: NRPN_LSB
-    type: null
-    value: 98
-  - description: null
-    max: 127
-    min: 0
-    name: NRPN_MSB
-    type: null
-    value: 99
-  - description: null
-    max: 127
-    min: 0
-    name: Tempo MSB
-    type: null
-    value: 106
-  - description: null
-    max: 127
-    min: 0
-    name: Tempo LSB
-    type: null
-    value: 107
-  - description: null
+  - description: Enters or Exits a folder
     max: 127
     min: 0
     name: Enter or Exit a folder
-    type: null
+    type: system
     value: 118
-  - description: 0 scrolls down song/folder list, 1 scrolls up
-    max: 1
+  - description: Scroll down song/folder list
+    max: 0
     min: 0
-    name: Scroll through song/folder list
-    type: null
+    name: Scroll down song/folder list
+    type: system
     value: 119
-  - description: null
+  - description: Scroll up song/folder list, 1 scrolls up
     max: 1
     min: 1
-    name: Emulate switch press function
-    type: null
-    value: 120
-  - description: null
+    name: Scroll up song/folder list
+    type: system
+    value: 119
+  - description: Emulates Main Pedal release
     max: 0
     min: 0
     name: Emulate switch release function
-    type: null
+    type: system
     value: 120
+  - description: Emulates Main Pedal press
+    max: 1
+    min: 1
+    name: Emulate switch press function
+    type: system
+    value: 120
+

--- a/data/mapping.json
+++ b/data/mapping.json
@@ -15,6 +15,16 @@
             ]
         },
         {
+            "name": "Atomic",
+            "value": "atomic",
+            "models": [
+                {
+                    "name": "Amplifire",
+                    "value": "amplifire"
+                }
+            ]
+        },
+        {
             "name": "Behringer",
             "value": "behringer",
             "models": [


### PR DESCRIPTION
Updated Aeros midi to v3.1.2 per https://docs.google.com/spreadsheets/d/16cNt2v0RL5adPzcpQASpr0PcTM8iEyBzbF6eOaz3j1o. 

Update BeatBuddy to latest from https://singularsound-publicly-downloadable.s3.us-east-2.amazonaws.com/manuals/BeatBuddy+Manual+(Firmware+3.9.9).pdf and https://docs.google.com/spreadsheets/d/16cNt2v0RL5adPzcpQASpr0PcTM8iEyBzbF6eOaz3j1o/edit#gid=488842810.  (but the manual at is better)

Added Atomic Amplfire based upon https://atomicamps.com/wp-content/uploads/2018/10/ATM_AmpliFire-Manual-6.0-1Final.pdf 

Mentioned a second, better, yaml linter that has much better error messages (that point to actual location of issues and not the outermost block).

Documented the type parameter in a cc block.

Note: 
- I added general cc usage and sysex info to the midi channel block.  Perhaps in a future release we can add a sysex block and/or a top level description/notes field.
- When midi commands were added in Aeros, I noted the version they were added in.


