### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ After a new yaml file is created, the `mapping.json` file needs to be updated to
     midi_channel: 
       instructions: |+
         [Description on how to set up the MIDI channel for the device]
+    
+    midi_mapping: [Yes | No]
+      description: |+
+        [Description of how MIDI is mapped on devices like Boss pedals, which require every MIDI CC to be user-defined]
 
     pc: 
       description: |+

--- a/data/brands/neuraldsp/quadcortex.yaml
+++ b/data/brands/neuraldsp/quadcortex.yaml
@@ -91,12 +91,32 @@ cc:
   - description: null
     max: 127
     min: 0
-    name: Tuner On/Off
+    name: Tuner On/Off (< CorOS 2.1.0)
+    value: 45
+  - description: null
+    max: 63
+    min: 0
+    name: Tuner Off (>= CorOS 2.1.0)
+    value: 45
+  - description: null
+    max: 127
+    min: 64
+    name: Tuner On (>= CorOS 2.1.0)
     value: 45
   - description: null
     max: 127
     min: 0
-    name: Open/Close Gig View
+    name: Open/Close Gig View (< CorOS 2.1.0)
+    value: 46
+  - description: null
+    max: 63
+    min: 0
+    name: Close Gig View (>= CorOS 2.1.0)
+    value: 46
+  - description: null
+    max: 127
+    min: 64
+    name: Open Gig View (>= CorOS 2.1.0)
     value: 46
   - description: null
     max: 0
@@ -113,7 +133,17 @@ cc:
     min: 2
     name: Change Mode - Stomp
     value: 47
-  - name: Open / Close Looper UI
+  - name: Open / Close Looper UI (< CorOS 2.1.0)
+    value: 48
+    description: ''
+    min: 64
+    max: 127
+  - name: Close Looper UI (>= CorOS 2.1.0)
+    value: 48
+    description: ''
+    min: 0
+    max: 63
+  - name: Open Looper UI (>= CorOS 2.1.0)
     value: 48
     description: ''
     min: 64


### PR DESCRIPTION
* added "midi_mapping" as a parameter in the yaml template
* updated quad cortex MIDI cc's to reflect CorOS 2.1.0 changes ( https://neuraldsp.com/quad-cortex-updates/coros-2-1-0-is-now-available )