### PR TITLE
Update syn20ir.yaml

### DIFF
--- a/data/brands/synergyamps/syn20ir.yaml
+++ b/data/brands/synergyamps/syn20ir.yaml
@@ -1,5 +1,5 @@
----
-midi_in: DIN7
+brand: Synergy Amps
+midi_in: DIN5
 midi_thru: No
 phantom_power: Yes
 midi_clock: No


### PR DESCRIPTION
My inital configration was merged just a few hours ago, so maybe  the changes haven't been fully published yet? If that's the case, this update can be ignored.

Currently, the Synergy Amps/Syn-IR20 appears in the Midi Dictionary list in the editor, but selecting it shows no info, properties or whatsoever.

If this was expected to work after the merge was performed, it doesn't. So I had a look and found some differences that I've updated.

Sorry for the inconvenience if this was my bad!
// W