### PR TITLE
Update syn20ir.yaml (include pc: description)

### DIFF
--- a/data/brands/synergyamps/syn20ir.yaml
+++ b/data/brands/synergyamps/syn20ir.yaml
@@ -10,6 +10,10 @@ midi_channel: |+
 
   Values and descriptions are based on the official Synergy Amps documentation (SYNERGY-SYN-20IR-MANUAL-FINAL-2-13-2025)
 
+pc: 
+  description: |+
+    SYN-20IR do not respond to PC messages. Only CC messages are used.
+
 cc:
   - name: Select channel
     value: "24"


### PR DESCRIPTION
Sorry, diving into the console debugging it turned out that pc.description was mandatory.

The SYN-IR20 only use CC, so I skipped that part.

Adding the property while debugging made it work, this should fix it.